### PR TITLE
fixed "Field 'parent' doesn't have a default value" (issue #4)

### DIFF
--- a/comments.class.php
+++ b/comments.class.php
@@ -175,7 +175,7 @@ class Comments_System
 					WHERE `id`= '".(int)$_POST['comm_reply']."' AND `parent`  = '0'")))					
 					$reply = ",`parent` = '".(int)$_POST['comm_reply']."'";
 				else
-					$reply = '';
+					$reply = ",`parent` = '0'";
 
 
 


### PR DESCRIPTION
In response to issue #4. This change should fix it. Works on my system.